### PR TITLE
바텀 네비게이션 바 컴포넌트 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,14 +7,20 @@ import Error from '@components/common/Error/Error';
 import Login from '@components/common/Login/Login';
 import ErrorBoundary from '@components/common/ErrorBoundary/ErrorBoundary';
 import { useResetError } from '@hooks/common/useResetError';
+import BottomNav from '@components/layout/BottomNav/BottomNav';
 
 function App() {
   return (
     <ErrorBoundary Fallback={Error} onReset={useResetError}>
       <Login>
-        <main>
-          <Outlet />
-        </main>
+        <div style={{ display: 'flex', flexDirection: 'column', maxHeight: '100dvh' }}>
+          <main
+            style={{ flex: '1 1 0%', margin: '49px 0 56px 0', overflowY: 'auto', width: '100%' }}
+          >
+            <Outlet />
+          </main>
+        </div>
+        <BottomNav />
       </Login>
       <ToastContainer
         position="top-center"

--- a/src/components/layout/BottomNav/BottomNav.style.ts
+++ b/src/components/layout/BottomNav/BottomNav.style.ts
@@ -1,0 +1,43 @@
+import styled from '@emotion/styled';
+
+export const FooterNav = styled.nav`
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  position: fixed;
+  width: 100%;
+  height: 56px;
+  bottom: 0;
+  padding: 0 20px;
+  background-color: ${(props) => props.theme.colors.black0};
+  justify-content: center;
+  align-items: center;
+  border-top-width: 1px;
+  z-index: 50;
+
+  @media (min-width: 768px) {
+    max-width: 768px;
+    left: 50%;
+    transform: translateX(-50%);
+  }
+
+  @media (min-width: 1024px) {
+    max-width: 1024px;
+  }
+`;
+
+export const NavButton = styled.button`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const NavSpan = styled.span`
+  color: ${(props) => props.theme.colors.black800};
+  font-size: 11px;
+  margin-top: 2px;
+  font-weight: 500;
+  word-wrap: break-word;
+`;

--- a/src/components/layout/BottomNav/BottomNav.tsx
+++ b/src/components/layout/BottomNav/BottomNav.tsx
@@ -1,0 +1,54 @@
+import { NavButton, NavSpan, FooterNav } from '@/components/layout/BottomNav/BottomNav.style';
+import SearchIcon from '@/assets/svg/search.svg?react';
+import { useNavigate } from 'react-router-dom';
+import { PATH } from '@/constants/path';
+
+const BottomNav = () => {
+  const navigate = useNavigate();
+
+  // 일단 임시적으로 상수를 설정하였습니다. 나중에 수정 해야함
+  const NAV_ITEMS = [
+    { id: 1, label: '홈', icon: <SearchIcon width="25" height="25" />, path: PATH.ROOT },
+    {
+      id: 2,
+      label: '놀이터 찾기',
+      icon: <SearchIcon width="25" height="25" />,
+      path: PATH.FIND_PLAYGROUND_FRIEND,
+    },
+    {
+      id: 3,
+      label: '모집글 등록',
+      icon: <SearchIcon width="25" height="25" />,
+      path: PATH.CREATE_PLAYGROUND,
+    },
+    {
+      id: 4,
+      label: '쪽지함',
+      icon: <SearchIcon width="25" height="25" />,
+      path: PATH.DIRECT_MESSAGE('22'),
+    },
+    {
+      id: 5,
+      label: '내정보',
+      icon: <SearchIcon width="25" height="25" />,
+      path: PATH.PROFILE('22'),
+    },
+  ];
+
+  const handleNavigation = (path: string) => {
+    navigate(path);
+  };
+
+  return (
+    <FooterNav>
+      {NAV_ITEMS.map((item) => (
+        <NavButton onClick={() => handleNavigation(item.path)}>
+          {item.icon}
+          <NavSpan>{item.label}</NavSpan>
+        </NavButton>
+      ))}
+    </FooterNav>
+  );
+};
+
+export default BottomNav;

--- a/src/components/layout/Header/Header.style.ts
+++ b/src/components/layout/Header/Header.style.ts
@@ -9,6 +9,16 @@ export const HeaderStyling = styled.header`
   width: 100%;
   background-color: ${(props) => props.theme.colors.black0};
   z-index: 50;
+
+  @media (min-width: 768px) {
+    max-width: 768px;
+    left: 50%;
+    transform: translateX(-50%);
+  }
+
+  @media (min-width: 1024px) {
+    max-width: 1024px;
+  }
 `;
 
 export const HeaderDiv = styled.div`
@@ -23,10 +33,13 @@ export const LeftDiv = styled.div`
   margin-right: auto;
 `;
 
-export const TitleDiv = styled.div`
+export const Title = styled.p`
   display: flex;
   grid-column: span 2 / span 2;
+  font-size: 18px;
+  font-weight: 900;
   justify-content: center;
+  color: ${(props) => props.theme.colors.black900};
 `;
 
 export const RightDiv = styled.div`

--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -3,11 +3,11 @@ import {
   HeaderStyling,
   LeftDiv,
   RightDiv,
-  TitleDiv,
+  Title,
 } from '@components/layout/Header/Header.style';
 
 interface HeaderProps {
-  title: string;
+  title?: string;
   leftIcon?: React.ReactNode;
   rightIcon?: React.ReactNode | string;
   onLeftClick?: () => void;
@@ -19,7 +19,7 @@ const Header = ({ title, leftIcon, rightIcon, onLeftClick, onRightClick }: Heade
     <HeaderStyling>
       <HeaderDiv>
         <LeftDiv>{leftIcon && <button onClick={onLeftClick}>{leftIcon}</button>}</LeftDiv>
-        <TitleDiv>{title}</TitleDiv>
+        <Title>{title}</Title>
         <RightDiv>{rightIcon && <button onClick={onRightClick}>{rightIcon}</button>}</RightDiv>
       </HeaderDiv>
     </HeaderStyling>

--- a/src/components/playGround/PlayGroundButton/PlayGroundButton.style.ts
+++ b/src/components/playGround/PlayGroundButton/PlayGroundButton.style.ts
@@ -4,7 +4,7 @@ import { Button } from '@radix-ui/themes';
 export const PlayGroundButtonStyling = styled(Button)`
   position: fixed;
   display: flex;
-  bottom: 40px;
+  bottom: 96px;
   left: 50%;
   transform: translateX(-50%);
   align-items: center;

--- a/src/pages/FindPlaygroundFriendPage/FindPlaygroundFriendPage.style.ts
+++ b/src/pages/FindPlaygroundFriendPage/FindPlaygroundFriendPage.style.ts
@@ -1,0 +1,6 @@
+import styled from '@emotion/styled';
+import { Flex } from '@radix-ui/themes';
+
+export const PlaygroundFlex = styled(Flex)`
+  height: calc(100dvh - 106px);
+`;

--- a/src/pages/FindPlaygroundFriendPage/FindPlaygroundFriendPage.tsx
+++ b/src/pages/FindPlaygroundFriendPage/FindPlaygroundFriendPage.tsx
@@ -1,4 +1,3 @@
-import { Flex } from '@radix-ui/themes';
 import { useNavigate } from 'react-router-dom';
 
 import CustomBottomSheet from '@/components/common/BottomSheet/CustomBottomSheet';
@@ -8,6 +7,7 @@ import PlayGroundSearchBar from '@/components/playGround/PlayGroundSearchBar/Pla
 import { useBottomSheet } from '@/hooks/common/useBottomSheet';
 import LeftIcon from '@assets/svg/left-icon.svg?react';
 import PlayGroundMap from '@/components/playGround/PlayGroundMap/PlayGroundMap';
+import { PlaygroundFlex } from '@/pages/FindPlaygroundFriendPage/FindPlaygroundFriendPage.style';
 
 const FindPlaygroundFriendPage = () => {
   const navigate = useNavigate();
@@ -19,7 +19,7 @@ const FindPlaygroundFriendPage = () => {
   const { isOpen, open, close } = useBottomSheet();
 
   return (
-    <Flex direction="column">
+    <PlaygroundFlex direction="column">
       <Header title="놀이터 찾기" leftIcon={<LeftIcon />} onLeftClick={goToBackPage} />
       <PlayGroundSearchBar />
       <button onClick={open}>바텀시트 열기</button>
@@ -29,7 +29,7 @@ const FindPlaygroundFriendPage = () => {
       </CustomBottomSheet>
       <PlayGroundMap />
       <PlayGroundButton />
-    </Flex>
+    </PlaygroundFlex>
   );
 };
 

--- a/src/pages/SignInPage/SignInPage.style.ts
+++ b/src/pages/SignInPage/SignInPage.style.ts
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 
 export const Container = styled.div`
   width: 100%;
-  height: 100vh;
+  height: calc(100dvh - 106px);
   background-color: ${(props) => props.theme.colors.black0};
   display: flex;
   flex-direction: column;

--- a/src/pages/SignInPage/SignInPage.tsx
+++ b/src/pages/SignInPage/SignInPage.tsx
@@ -2,10 +2,7 @@ import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 import {
   Container,
-  HeaderContainer,
-  CancelButton,
   LogoContainer,
-  Logo,
   Form,
   FormGroup,
   Label,
@@ -16,6 +13,9 @@ import {
   Footer,
   FooterLink,
 } from './SignInPage.style';
+import Header from '@/components/layout/Header/Header';
+import CancelIcon from '@/assets/svg/cancel.svg?react';
+import LogoIcon from '@/assets/svg/logo-vertical.svg?react';
 
 interface FormData {
   email: string;
@@ -41,11 +41,9 @@ const SignInPage = () => {
 
   return (
     <Container>
-      <HeaderContainer>
-        <CancelButton src="/src/assets/svg/cancel.svg" />
-      </HeaderContainer>
+      <Header rightIcon={<CancelIcon />} />
       <LogoContainer>
-        <Logo src="/src/assets/svg/logo-vertical.svg" alt="Playground Logo" />
+        <LogoIcon width={140} height={85} />
       </LogoContainer>
       <Form onSubmit={handleSubmit(onSubmit)} noValidate>
         <FormGroup>

--- a/src/pages/SignUpPage/SignUpPage.style.ts
+++ b/src/pages/SignUpPage/SignUpPage.style.ts
@@ -5,7 +5,7 @@ import { Button } from '@radix-ui/themes';
 
 export const Container = styled.div`
   width: 100%;
-  height: 100vh;
+  height: calc(100dvh - 106px);
   position: relative;
   display: flex;
   flex-direction: column;
@@ -51,6 +51,7 @@ export const Form = styled.form`
   flex-direction: column;
   gap: 16px;
   padding: 16px;
+  flex: 1;
 `;
 
 export const InputContainer = styled.div`
@@ -158,12 +159,10 @@ export const SubmitButton = styled(Button)`
   width: calc(100% - 32px);
   height: 50px;
   max-width: 400px;
-
-  position: fixed;
   bottom: 16px;
-  left: 50%;
-  transform: translateX(-50%);
 
+  align-self: center;
+  margin-top: auto;
   background-color: ${({ disabled, theme }) =>
     disabled ? theme.colors.black400 : theme.colors.primary1};
   color: ${({ disabled, theme }) => (disabled ? theme.colors.black600 : theme.colors.black900)};

--- a/src/pages/SignUpPage/SignUpPage.tsx
+++ b/src/pages/SignUpPage/SignUpPage.tsx
@@ -2,12 +2,9 @@ import { useForm } from 'react-hook-form';
 import { CheckIcon } from '@radix-ui/react-icons';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+
 import {
   Container,
-  HeaderContainer,
-  LeftIcon,
-  Title,
-  ToLogin,
   Form,
   InputContainer,
   Label,
@@ -24,6 +21,9 @@ import {
   DuplicateCheckButton,
 } from './SignUpPage.style.ts';
 import SignUpCompletePopup from './SignUpCompletePopup.tsx';
+import Header from '@/components/layout/Header/Header.tsx';
+import LeftIcon from '@/assets/svg/left-icon.svg?react';
+import { PATH } from '@/constants/path.ts';
 
 interface FormData {
   name: string;
@@ -72,11 +72,13 @@ const SignUpPage = () => {
 
   return (
     <Container>
-      <HeaderContainer>
-        <LeftIcon src="/src/assets/svg/left-icon.svg" alt="LeftIcon" onClick={() => navigate(-1)} />
-        <Title>회원가입</Title>
-        <ToLogin to="/sign-in">로그인</ToLogin>
-      </HeaderContainer>
+      <Header
+        title="회원가입"
+        leftIcon={<LeftIcon />}
+        onLeftClick={() => navigate(-1)}
+        rightIcon="로그인"
+        onRightClick={() => navigate(PATH.SIGNIN)}
+      />
       <Form onSubmit={handleSubmit(onSubmit)}>
         <InputContainer>
           <Label htmlFor="name">이름</Label>

--- a/src/styles/GlobalStyle.ts
+++ b/src/styles/GlobalStyle.ts
@@ -26,9 +26,10 @@ export const globalStyles = css`
       'Helvetica Neue';
     font-size: 16px;
     min-width: 360px;
-    min-height: 100vh;
+    height: 100dvh;
     margin: 0 auto;
-    padding: 46px 0px 16px 0px;
+    min-height: calc(100dvh - 106px);
+    /* padding: 46px 0px 56px 0px; */
 
     // 터치 동작 최적화
     -webkit-touch-callout: none;
@@ -46,13 +47,13 @@ export const globalStyles = css`
     @media (min-width: 768px) {
       // 태블릿
       max-width: 768px;
-      padding: 46px 0px 24px 0px;
+      /* padding: 46px 0px 56px 0px; */
     }
 
     @media (min-width: 1024px) {
       // 데스크탑
       max-width: 1024px;
-      padding: 46px 0px 32px 0px;
+      /* padding: 46px 0px 56px 0px; */
     }
   }
 


### PR DESCRIPTION
## 🚀 Related Issues

> #21 

## 🛠️ Summary

1. **화면 높이 조정**
 기존 화면에서는 height가 길어 스크롤이 발생하는 문제가 있었습니다. 이를 해결하기 위하여 100dvh에서 헤더(46px)와 바텀 네비게이션 바(56px)의 길이를 뺀 calc(100dvh - 106px)로 height의 크기를 설정하였습니다. 참고로, 46px과 56px의 합은 102px이지만, 102px을 뺐을 때도 스크롤이 발생하여 추가로 4px을 더 제거했습니다.

2. **바텀 네비게이션 바**
바텀 네비게이션 바의 아이콘은 아직 디자인이 나오지 않아 임시 아이콘을 사용했으며, 라우팅 설정은 쪽지함과 내 정보 페이지를 임시로 지정해 두었습니다. (추후 수정 예정)

3. **회원가입 및 로그인 페이지**
회원가입 페이지와 로그인 페이지는 크게 수정하지 않았습니다. 머지 시 충돌이 발생할 수는 있지만, 수정해야 할 부분은 많지 않을 것으로 보입니다.

## 💬 Review Requirements

### 페이지 감싸실 때 Container로 설정하셔서 사용하시는데 여기서 height는 calc(100dvh - 106px)로 설정해주세요! (진짜 중요)
이 크기가 딱 스크롤이 생기지 않으면서 화면을 다 채울 수 있는 설정이라서 모바일 환경 고려하면 이렇게 개발해야할 것 같습니다. (혹시 이렇게 설정하시다가 이상한 점 발견하시면 저한테 말해주세요)
<details><summary>vh가 아니라 dvh로 설정하는 이유
</summary>

100vh (Viewport Height):
- 브라우저의 뷰포트 전체 높이를 기준으로 합니다
- 모바일 브라우저에서 주소창, 네비게이션 바 등의 UI 요소를 포함한 전체 높이를 계산합니다
- 이로 인해 모바일에서 스크롤 시 주소창이 사라지면서 레이아웃이 깨지는 현상이 발생할 수 있습니다

100dvh (Dynamic Viewport Height):
- 실제로 보이는 화면 높이만을 기준으로 합니다
- 모바일 브라우저의 동적 UI 요소들을 제외한 실제 가시 영역만을 계산합니다
- 주소창이나 네비게이션 바가 나타나고 사라져도 일관된 레이아웃을 유지합니다

추천하는 사용법:
1. 모바일 환경이 중요한 경우: 100dvh 사용을 추천합니다. 특히 전체 화면 레이아웃이나 모달 등에 적합합니다.

2. 데스크톱 중심 웹사이트: 100vh를 사용해도 큰 문제가 없습니다.

3. 크로스 브라우저 호환성이 중요한 경우: dvh는 비교적 최신 기능이므로, 폴백(fallback)으로 vh를 함께 사용하는 것이 좋습니다.

```css
.full-height {
  height: 100vh; /* 폴백 */
  height: 100dvh; /* 모던 브라우저 지원 */
}
```

전반적으로는 100dvh 사용을 추천드립니다. 모바일 환경에서 더 안정적인 사용자 경험을 제공하며, 점차 더 많은 브라우저가 지원하고 있기 때문입니다.
</details>

- 그리고 SignUpPage.style.ts 부분에 Container에 `flex: 1;` 을 설정한 이유는 flex-grow: 1, flex-shrink: 1, flex-basis: 0%를 동시에 설정하는 축약형이기 때문입니다.
이를 사용하면 컨테이너가 부모 요소 내에서 남은 공간을 모두 채우고, 필요 시 유연하게 크기가 조정됩니다.
또한, InputContainer에 margin-top: auto;를 적용하여 완료 버튼이 화면 하단에 배치되도록 구현했습니다.
