### PR TITLE
쪽지함 페이지 퍼블리싱

### DIFF
--- a/src/components/common/Card/Card.style.ts
+++ b/src/components/common/Card/Card.style.ts
@@ -1,0 +1,46 @@
+import styled from '@emotion/styled';
+import { Avatar, Flex } from '@radix-ui/themes';
+
+export const CardFlex = styled(Flex)`
+  position: relative;
+  width: 100%;
+  padding: 8px 16px;
+`;
+
+export const CardMain = styled(Flex)`
+  width: 100%;
+  height: 100%;
+
+  background-color: ${(props) => props.theme.colors.black100};
+  border-radius: 16px;
+  padding: 20px;
+  flex-direction: column;
+  gap: 11px;
+`;
+
+export const CardHeader = styled(Flex)`
+  justify-content: space-between;
+`;
+
+export const CardContent = styled.span`
+  color: ${(props) => props.theme.colors.black800};
+  font-size: 15px;
+`;
+
+export const CardAvatar = styled(Avatar)``;
+
+export const CardUser = styled(Flex)`
+  flex-direction: column;
+  justify-content: center;
+  gap: 3px;
+`;
+
+export const CardNickname = styled.span`
+  color: ${(props) => props.theme.colors.black800};
+  font-weight: 600;
+`;
+
+export const CardInfo = styled.span`
+  color: ${(props) => props.theme.colors.black600};
+  font-size: 14px;
+`;

--- a/src/components/common/Card/Card.tsx
+++ b/src/components/common/Card/Card.tsx
@@ -1,0 +1,40 @@
+import {
+  CardFlex,
+  CardMain,
+  CardAvatar,
+  CardHeader,
+  CardContent,
+  CardUser,
+  CardNickname,
+  CardInfo,
+} from '@/components/common/Card/Card.style';
+
+interface CardProps {
+  onClick?: () => void;
+  nickname: string;
+  status: string;
+  address: string;
+  image: string;
+  content?: string;
+}
+
+const Card = ({ onClick, nickname, status, address, image, content }: CardProps) => {
+  return (
+    <CardFlex onClick={onClick}>
+      <CardMain>
+        <CardHeader>
+          <CardUser>
+            <CardNickname>{nickname}</CardNickname>
+            <CardInfo>
+              {status}·{address}
+            </CardInfo>
+          </CardUser>
+          <CardAvatar size="5" src={image} fallback="A" radius="full" />
+        </CardHeader>
+        <CardContent>{content}</CardContent>
+      </CardMain>
+    </CardFlex>
+  );
+};
+
+export default Card;

--- a/src/components/common/RequirementRoom/RequirementRoom.style.ts
+++ b/src/components/common/RequirementRoom/RequirementRoom.style.ts
@@ -1,0 +1,45 @@
+import styled from '@emotion/styled';
+import { Flex } from '@radix-ui/themes';
+
+export const RequirementFlex = styled(Flex)`
+  position: relative;
+  flex-direction: column;
+  justify-content: flex-start;
+  gap: 8px;
+  padding: 20px 16px;
+  cursor: pointer;
+
+  &::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 16px;
+    right: 16px;
+    height: 1px;
+    background-color: ${(props) => props.theme.colors.black500};
+  }
+`;
+
+export const RequirementHeader = styled(Flex)`
+  align-items: center;
+  gap: 8px;
+`;
+
+export const RequirementTag = styled(Flex)``;
+
+export const RequirementJoin = styled.span`
+  font-size: 12px;
+  font-weight: 600;
+`;
+
+export const RequirementTitle = styled.span``;
+
+export const RequirementDescription = styled.span`
+  font-size: 15px;
+  color: ${(props) => props.theme.colors.black500};
+`;
+
+export const RequirementTime = styled.span`
+  font-size: 13px;
+  color: ${(props) => props.theme.colors.black500};
+`;

--- a/src/components/common/RequirementRoom/RequirementRoom.tsx
+++ b/src/components/common/RequirementRoom/RequirementRoom.tsx
@@ -1,0 +1,41 @@
+import {
+  RequirementDescription,
+  RequirementFlex,
+  RequirementHeader,
+  RequirementJoin,
+  RequirementTag,
+  RequirementTime,
+  RequirementTitle,
+} from '@/components/common/RequirementRoom/RequirementRoom.style';
+
+interface RequirementRoomProps {
+  onClick: () => void;
+  status: string;
+  currentCount: number;
+  title: string;
+  description: string;
+  playTime: string;
+}
+
+const RequirementRoom = ({
+  onClick,
+  status,
+  currentCount,
+  title,
+  description,
+  playTime,
+}: RequirementRoomProps) => {
+  return (
+    <RequirementFlex onClick={onClick}>
+      <RequirementHeader>
+        <RequirementTag>{status}</RequirementTag>
+        <RequirementJoin>{currentCount}명 참여 중</RequirementJoin>
+      </RequirementHeader>
+      <RequirementTitle>{title}</RequirementTitle>
+      <RequirementDescription>{description}</RequirementDescription>
+      <RequirementTime>{playTime}</RequirementTime>
+    </RequirementFlex>
+  );
+};
+
+export default RequirementRoom;

--- a/src/components/common/SendMessageButton/SendMessageButton.style.ts
+++ b/src/components/common/SendMessageButton/SendMessageButton.style.ts
@@ -1,0 +1,15 @@
+import styled from '@emotion/styled';
+import { Button } from '@radix-ui/themes';
+
+export const SendButton = styled(Button)`
+  width: 90%;
+  padding: 24px;
+  font-size: 16px;
+  font-weight: 600;
+  align-self: center;
+  border-radius: 8px;
+  color: ${({ theme }) => theme.colors.black900};
+  background-color: ${({ theme }) => theme.colors.primary1};
+  margin-top: auto;
+  margin-bottom: 24px;
+`;

--- a/src/components/common/SendMessageButton/SendMessageButton.tsx
+++ b/src/components/common/SendMessageButton/SendMessageButton.tsx
@@ -1,0 +1,7 @@
+import { SendButton } from '@/components/common/SendMessageButton/SendMessageButton.style';
+
+const SendMessageButton = () => {
+  return <SendButton>쪽지 보내기</SendButton>;
+};
+
+export default SendMessageButton;

--- a/src/components/common/Tab/Tab.style.ts
+++ b/src/components/common/Tab/Tab.style.ts
@@ -1,0 +1,26 @@
+import styled from '@emotion/styled';
+
+export const TabRoot = styled.div`
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  width: 100%;
+  color: ${({ theme }) => theme.colors.black700};
+  border-bottom: 1px solid ${({ theme }) => theme.colors.black400};
+  font-weight: 700;
+  cursor: pointer;
+`;
+
+export const TabsList = styled.div<{ isActive: boolean }>`
+  display: flex;
+  padding: 1rem 0;
+  flex-direction: column;
+  align-items: center;
+  border-bottom-width: 1px;
+
+  ${({ isActive, theme }) =>
+    isActive &&
+    `
+    border-bottom: 3px solid ${theme.colors.black800};
+    color: ${theme.colors.black900};
+  `}
+`;

--- a/src/components/common/Tab/Tab.tsx
+++ b/src/components/common/Tab/Tab.tsx
@@ -1,0 +1,28 @@
+import { DIRECT_MESSAGE } from '@/constants/message';
+import { useTab } from '@/hooks/common/useTab';
+import { TabRoot, TabsList } from '@/components/common/Tab/Tab.style';
+
+const Tab = () => {
+  const { tab, setTab } = useTab();
+
+  const onClickRecruitment = () => {
+    setTab(DIRECT_MESSAGE.RECRUITMENT);
+  };
+
+  const onClickFriend = () => {
+    setTab(DIRECT_MESSAGE.FRIEND);
+  };
+
+  return (
+    <TabRoot>
+      <TabsList onClick={onClickRecruitment} isActive={tab === DIRECT_MESSAGE.RECRUITMENT}>
+        {DIRECT_MESSAGE.RECRUITMENT}
+      </TabsList>
+      <TabsList onClick={onClickFriend} isActive={tab === DIRECT_MESSAGE.FRIEND}>
+        {DIRECT_MESSAGE.FRIEND}
+      </TabsList>
+    </TabRoot>
+  );
+};
+
+export default Tab;

--- a/src/components/common/TextInput/TextInput.style.ts
+++ b/src/components/common/TextInput/TextInput.style.ts
@@ -1,0 +1,52 @@
+import styled from '@emotion/styled';
+import { Button, Flex } from '@radix-ui/themes';
+
+export const TextInputFlex = styled(Flex)`
+  flex: 1;
+  flex-direction: column;
+  align-items: center;
+  gap: 5px;
+`;
+
+export const ReportTitleSpan = styled.span`
+  width: 90%;
+  align-self: flex-start;
+`;
+
+export const ReportTextFlex = styled(Flex)`
+  width: 90%;
+  padding: 16px;
+  flex-direction: column;
+  background-color: ${({ theme }) => theme.colors.black200};
+  border-radius: 6px;
+`;
+
+export const ReportTextArea = styled.textarea`
+  display: block;
+  width: 100%;
+  height: 150px;
+  color: ${({ theme }) => theme.colors.black900};
+  background-color: ${({ theme }) => theme.colors.black200};
+  resize: none;
+  border: none;
+  outline: none;
+  flex-grow: 1;
+  cursor: auto;
+  font-size: 14px;
+  line-height: 20px;
+`;
+
+export const LengthSpan = styled.span`
+  align-self: flex-end;
+  color: ${({ theme }) => theme.colors.black700};
+`;
+
+export const ReportButton = styled(Button)`
+  width: 90%;
+  margin-top: auto;
+  margin-bottom: 5px;
+  padding: 20px 0;
+  background-color: ${({ disabled, theme }) =>
+    disabled ? theme.colors.black400 : theme.colors.primary1};
+  color: ${({ disabled, theme }) => (disabled ? theme.colors.black600 : theme.colors.black900)};
+`;

--- a/src/components/common/TextInput/TextInput.tsx
+++ b/src/components/common/TextInput/TextInput.tsx
@@ -1,0 +1,46 @@
+import { ChangeEvent, useState } from 'react';
+import { Flex } from '@radix-ui/themes';
+
+import { TEXT_MAX_LENGTH } from '@/constants/text';
+import {
+  LengthSpan,
+  ReportButton,
+  ReportTextArea,
+  ReportTextFlex,
+  ReportTitleSpan,
+  TextInputFlex,
+} from '@/components/common/TextInput/TextInput.style';
+
+interface TextInputProps {
+  placeholder: string;
+  buttonLabel: string;
+}
+
+const TextInput = ({ placeholder, buttonLabel }: TextInputProps) => {
+  const [text, setText] = useState<string>('');
+
+  const onChangeText = (event: ChangeEvent<HTMLTextAreaElement>) => {
+    const inputValue = event.target.value;
+
+    if (inputValue.length <= TEXT_MAX_LENGTH) {
+      setText(inputValue);
+    }
+  };
+
+  return (
+    <TextInputFlex>
+      <Flex width="90%">
+        <ReportTitleSpan>내용</ReportTitleSpan>
+      </Flex>
+      <ReportTextFlex>
+        <ReportTextArea placeholder={placeholder} value={text} onChange={onChangeText} />
+        <LengthSpan>
+          {text.length}/{TEXT_MAX_LENGTH}자
+        </LengthSpan>
+      </ReportTextFlex>
+      <ReportButton disabled={!text}>{buttonLabel}</ReportButton>
+    </TextInputFlex>
+  );
+};
+
+export default TextInput;

--- a/src/components/layout/Header/Header.style.ts
+++ b/src/components/layout/Header/Header.style.ts
@@ -34,12 +34,15 @@ export const LeftDiv = styled.div`
 `;
 
 export const Title = styled.p`
-  display: flex;
   grid-column: span 2 / span 2;
   font-size: 18px;
   font-weight: 900;
-  justify-content: center;
+  text-align: center;
   color: ${(props) => props.theme.colors.black900};
+
+  white-space: nowrap; /* 한 줄로 표시 */
+  overflow: hidden; /* 넘치는 텍스트 숨기기 */
+  text-overflow: ellipsis; /* 생략(...) 처리 */
 `;
 
 export const RightDiv = styled.div`

--- a/src/constants/message.ts
+++ b/src/constants/message.ts
@@ -1,0 +1,1 @@
+export const DIRECT_MESSAGE = { RECRUITMENT: '모집글', FRIEND: '친구' } as const;

--- a/src/constants/path.ts
+++ b/src/constants/path.ts
@@ -7,6 +7,7 @@ export const PATH = {
   FIND_PLAYGROUND_FRIEND: '/find-playground-friend',
   CREATE_PLAYGROUND: '/create-playground',
   PLAYGROUND_SEARCH: '/playground-search',
+  FRIEND_MESSAGE: (userId: string) => `/friend-message/${userId}`,
   PLAYGROUND_MESSAGE: (playgroundId: string) => `/playground-message/${playgroundId}`,
   PLAYGROUND_ROOM: (playgroundId: string) => `/playground-room/${playgroundId}`,
   EDIT_ACCOUNT: (userId: string) => `/edit-account/${userId}`,
@@ -16,6 +17,5 @@ export const PATH = {
   FRIENDS_PLAYED: (userId: string) => `/friends-played/${userId}`,
   REPORT_FRIEND: (userId: string) => `/report-friend/${userId}`,
   DIRECT_MESSAGE: (userId: string) => `/direct-message/${userId}`,
-  CONTACT_US: '/contact-us',
   RELOAD: 0,
 } as const;

--- a/src/hooks/common/useTab.ts
+++ b/src/hooks/common/useTab.ts
@@ -1,0 +1,18 @@
+import { create } from 'zustand';
+
+import { DIRECT_MESSAGE } from '@/constants/message';
+import { DirectMessageType } from '@/types/message';
+
+interface TabState {
+  tab: DirectMessageType;
+  setTab: (tab: DirectMessageType) => void;
+}
+
+export const useTab = create<TabState>((set) => ({
+  tab: DIRECT_MESSAGE.RECRUITMENT,
+  setTab: (tab) => {
+    set({
+      tab,
+    });
+  },
+}));

--- a/src/pages/ContactUsPage/ContactUsPage.tsx
+++ b/src/pages/ContactUsPage/ContactUsPage.tsx
@@ -1,5 +1,0 @@
-const ContactUsPage = () => {
-  return <div>문의 페이지입니다.</div>;
-};
-
-export default ContactUsPage;

--- a/src/pages/DirectMessagePage/DirectMessagePage.style.ts
+++ b/src/pages/DirectMessagePage/DirectMessagePage.style.ts
@@ -1,0 +1,8 @@
+import styled from '@emotion/styled';
+import { Flex } from '@radix-ui/themes';
+
+export const DirectMessageFlex = styled(Flex)`
+  flex-direction: column;
+  height: calc(100dvh - 106px);
+  flex: 1;
+`;

--- a/src/pages/DirectMessagePage/DirectMessagePage.tsx
+++ b/src/pages/DirectMessagePage/DirectMessagePage.tsx
@@ -1,5 +1,76 @@
+import Card from '@/components/common/Card/Card';
+import RequirementRoom from '@/components/common/RequirementRoom/RequirementRoom';
+import Tab from '@/components/common/Tab/Tab';
+import Header from '@/components/layout/Header/Header';
+import { DIRECT_MESSAGE } from '@/constants/message';
+import { PATH } from '@/constants/path';
+import { useTab } from '@/hooks/common/useTab';
+import { DirectMessageFlex } from '@/pages/DirectMessagePage/DirectMessagePage.style';
+import { useNavigate } from 'react-router-dom';
+
+const requireData = [
+  {
+    playgroundId: '25',
+    status: '모집 중',
+    currentCount: 2,
+    title: '내일 서리풀 놀이터에서 놀 친구 구해요',
+    description: '안녕하세요 저는 6살 애기 아빠이고, 서초구에서 살..',
+    playTime: '11.24 금요일·오후 3:00~4:00',
+  },
+];
+
+const cardData = [
+  {
+    friendId: '22',
+    nickname: '닉네임',
+    status: '아빠',
+    address: '서울시 노원구 중계동',
+    image:
+      'https://images.unsplash.com/photo-1607346256330-dee7af15f7c5?&w=64&h=64&dpr=2&q=70&crop=focalpoint&fp-x=0.67&fp-y=0.5&fp-z=1.4&fit=crop',
+    content: '쪽지 내용입니다.',
+  },
+];
+
 const DirectMessagePage = () => {
-  return <div>쪽지함 페이지입니다.</div>;
+  const navigate = useNavigate();
+  const { tab } = useTab();
+
+  const goToPlaygroundMessage = (playgroundId: string) => () => {
+    navigate(PATH.PLAYGROUND_MESSAGE(playgroundId));
+  };
+
+  const goToFriendMessage = (userId: string) => () => {
+    navigate(PATH.FRIEND_MESSAGE(userId));
+  };
+
+  return (
+    <DirectMessageFlex>
+      <Header title="쪽지함" />
+      <Tab />
+      {tab === DIRECT_MESSAGE.RECRUITMENT &&
+        requireData.map((items) => (
+          <RequirementRoom
+            onClick={goToPlaygroundMessage(items.playgroundId)}
+            status={items.status}
+            currentCount={items.currentCount}
+            title={items.title}
+            description={items.description}
+            playTime={items.playTime}
+          />
+        ))}
+      {tab === DIRECT_MESSAGE.FRIEND &&
+        cardData.map((items) => (
+          <Card
+            onClick={goToFriendMessage(items.friendId)}
+            nickname={items.nickname}
+            status={items.status}
+            address={items.address}
+            image={items.image}
+            content={items.content}
+          />
+        ))}
+    </DirectMessageFlex>
+  );
 };
 
 export default DirectMessagePage;

--- a/src/pages/FriendMessagePage/FriendMessagePage.style.ts
+++ b/src/pages/FriendMessagePage/FriendMessagePage.style.ts
@@ -1,0 +1,8 @@
+import styled from '@emotion/styled';
+import { Flex } from '@radix-ui/themes';
+
+export const FriendMessageFlex = styled(Flex)`
+  flex-direction: column;
+  height: calc(100dvh - 106px);
+  flex: 1;
+`;

--- a/src/pages/FriendMessagePage/FriendMessagePage.tsx
+++ b/src/pages/FriendMessagePage/FriendMessagePage.tsx
@@ -1,0 +1,42 @@
+import { useNavigate } from 'react-router-dom';
+
+import Header from '@/components/layout/Header/Header';
+import { FriendMessageFlex } from '@/pages/FriendMessagePage/FriendMessagePage.style';
+import LeftIcon from '@assets/svg/left-icon.svg?react';
+import Card from '@/components/common/Card/Card';
+
+const cardData = [
+  {
+    nickname: '닉네임',
+    status: '아빠',
+    address: '서울시 노원구 중계동',
+    image:
+      'https://images.unsplash.com/photo-1607346256330-dee7af15f7c5?&w=64&h=64&dpr=2&q=70&crop=focalpoint&fp-x=0.67&fp-y=0.5&fp-z=1.4&fit=crop',
+    content: '쪽지 내용입니다.',
+  },
+];
+
+const FriendMessagePage = () => {
+  const navigate = useNavigate();
+
+  const goToBack = () => {
+    navigate(-1);
+  };
+
+  return (
+    <FriendMessageFlex>
+      <Header title="쪽지 내용" leftIcon={<LeftIcon />} onLeftClick={goToBack} />
+      {cardData.map((items) => (
+        <Card
+          nickname={items.nickname}
+          status={items.status}
+          address={items.address}
+          image={items.image}
+          content={items.content}
+        />
+      ))}
+    </FriendMessageFlex>
+  );
+};
+
+export default FriendMessagePage;

--- a/src/pages/PlaygroundMessagePage/PlaygroundMessagePage.style.ts
+++ b/src/pages/PlaygroundMessagePage/PlaygroundMessagePage.style.ts
@@ -1,0 +1,29 @@
+import styled from '@emotion/styled';
+import { Button, Flex } from '@radix-ui/themes';
+
+export const PlayGroundRoomFlex = styled(Flex)`
+  width: 100%;
+  flex-direction: column;
+  align-items: center;
+  height: calc(100dvh - 106px);
+  flex: 1;
+`;
+
+export const SendMessageButton = styled(Button)`
+  width: 90%;
+  padding: 30px 0;
+  font-size: 18px;
+  font-weight: 600;
+  margin-top: auto;
+  border-radius: 8px;
+  color: ${({ theme }) => theme.colors.black900};
+  background-color: ${({ theme }) => theme.colors.primary1};
+  cursor: pointer;
+`;
+
+export const BottomSheetTitle = styled.h2`
+  color: ${({ theme }) => theme.colors.black900};
+  font-weight: 700;
+  text-align: center;
+  margin-bottom: 16px;
+`;

--- a/src/pages/PlaygroundMessagePage/PlaygroundMessagePage.tsx
+++ b/src/pages/PlaygroundMessagePage/PlaygroundMessagePage.tsx
@@ -1,5 +1,59 @@
+import { useNavigate } from 'react-router-dom';
+
+import CustomBottomSheet from '@/components/common/BottomSheet/CustomBottomSheet';
+import TextInput from '@/components/common/TextInput/TextInput';
+import { useBottomSheet } from '@/hooks/common/useBottomSheet';
+import {
+  PlayGroundRoomFlex,
+  SendMessageButton,
+  BottomSheetTitle,
+} from '@/pages/PlaygroundMessagePage/PlaygroundMessagePage.style';
+import Header from '@/components/layout/Header/Header';
+import Card from '@/components/common/Card/Card';
+import LeftIcon from '@assets/svg/left-icon.svg?react';
+
+const cardData = [
+  {
+    nickname: '닉네임',
+    status: '아빠',
+    address: '서울시 노원구 중계동',
+    image:
+      'https://images.unsplash.com/photo-1607346256330-dee7af15f7c5?&w=64&h=64&dpr=2&q=70&crop=focalpoint&fp-x=0.67&fp-y=0.5&fp-z=1.4&fit=crop',
+    content: '쪽지 내용입니다.',
+  },
+];
+
 const PlaygroundMessagePage = () => {
-  return <div>놀이터 쪽지함 페이지입니다.</div>;
+  const navigate = useNavigate();
+  const { isOpen, open, close } = useBottomSheet();
+
+  const goToBack = () => {
+    navigate(-1);
+  };
+
+  return (
+    <PlayGroundRoomFlex>
+      <Header
+        title="동해물과 백두산이 마르고 닳도록 하느님이 보우하사 우리나라만세"
+        leftIcon={<LeftIcon />}
+        onLeftClick={goToBack}
+      />
+      {cardData.map((items) => (
+        <Card
+          nickname={items.nickname}
+          status={items.status}
+          address={items.address}
+          image={items.image}
+          content={items.content}
+        />
+      ))}
+      <SendMessageButton onClick={open}>쪽지 보내기</SendMessageButton>
+      <CustomBottomSheet isOpen={isOpen} onClose={close}>
+        <BottomSheetTitle>쪽지 작성</BottomSheetTitle>
+        <TextInput placeholder="내용을 입력해 주세요." buttonLabel="보내기" />
+      </CustomBottomSheet>
+    </PlayGroundRoomFlex>
+  );
 };
 
 export default PlaygroundMessagePage;

--- a/src/pages/ReportFriendPage/ReportFriendPage.style.ts
+++ b/src/pages/ReportFriendPage/ReportFriendPage.style.ts
@@ -1,53 +1,7 @@
 import styled from '@emotion/styled';
-import { Button, Flex } from '@radix-ui/themes';
+import { Flex } from '@radix-ui/themes';
 
 export const ReportFriendFlex = styled(Flex)`
   height: calc(100dvh - 106px);
   flex: 1;
-  flex-direction: column;
-  align-items: center;
-  gap: 5px;
-`;
-
-export const ReportTitleSpan = styled.span`
-  width: 90%;
-  align-self: flex-start;
-`;
-
-export const ReportTextFlex = styled(Flex)`
-  width: 90%;
-  padding: 16px;
-  flex-direction: column;
-  background-color: ${({ theme }) => theme.colors.black200};
-  border-radius: 6px;
-`;
-
-export const ReportTextArea = styled.textarea`
-  display: block;
-  width: 100%;
-  height: 150px;
-  color: ${({ theme }) => theme.colors.black900};
-  background-color: ${({ theme }) => theme.colors.black200};
-  resize: none;
-  border: none;
-  outline: none;
-  flex-grow: 1;
-  cursor: auto;
-  font-size: 14px;
-  line-height: 20px;
-`;
-
-export const LengthSpan = styled.span`
-  align-self: flex-end;
-  color: ${({ theme }) => theme.colors.black700};
-`;
-
-export const ReportButton = styled(Button)`
-  width: 90%;
-  margin-top: auto;
-  margin-bottom: 5px;
-  padding: 20px 0;
-  background-color: ${({ disabled, theme }) =>
-    disabled ? theme.colors.black400 : theme.colors.primary1};
-  color: ${({ disabled, theme }) => (disabled ? theme.colors.black600 : theme.colors.black900)};
 `;

--- a/src/pages/ReportFriendPage/ReportFriendPage.tsx
+++ b/src/pages/ReportFriendPage/ReportFriendPage.tsx
@@ -1,30 +1,12 @@
 import { useNavigate } from 'react-router-dom';
 
 import Header from '@/components/layout/Header/Header';
-import {
-  LengthSpan,
-  ReportButton,
-  ReportFriendFlex,
-  ReportTextArea,
-  ReportTextFlex,
-  ReportTitleSpan,
-} from '@/pages/ReportFriendPage/ReportFriendPage.style';
+import { ReportFriendFlex } from '@/pages/ReportFriendPage/ReportFriendPage.style';
 import LeftIcon from '@/assets/svg/left-icon.svg?react';
-import { ChangeEvent, useState } from 'react';
-import { TEXT_MAX_LENGTH } from '@/constants/text';
-import { Flex } from '@radix-ui/themes';
+import TextInput from '@/components/common/TextInput/TextInput';
 
 const ReportFriendPage = () => {
   const navigate = useNavigate();
-  const [text, setText] = useState<string>('');
-
-  const onChangeText = (event: ChangeEvent<HTMLTextAreaElement>) => {
-    const inputValue = event.target.value;
-
-    if (inputValue.length <= TEXT_MAX_LENGTH) {
-      setText(inputValue);
-    }
-  };
 
   const goBackToPage = () => {
     navigate(-1);
@@ -33,20 +15,10 @@ const ReportFriendPage = () => {
   return (
     <ReportFriendFlex>
       <Header title="신고하기" leftIcon={<LeftIcon />} onLeftClick={goBackToPage} />
-      <Flex width="90%">
-        <ReportTitleSpan>내용</ReportTitleSpan>
-      </Flex>
-      <ReportTextFlex>
-        <ReportTextArea
-          placeholder="친구를 신고하는 이유와 자세한 상황을 설명해 주세요."
-          value={text}
-          onChange={onChangeText}
-        />
-        <LengthSpan>
-          {text.length}/{TEXT_MAX_LENGTH}자
-        </LengthSpan>
-      </ReportTextFlex>
-      <ReportButton disabled={!text}>완료</ReportButton>
+      <TextInput
+        placeholder="친구를 신고하는 이유와 자세한 상황을 설명해 주세요."
+        buttonLabel="완료"
+      />
     </ReportFriendFlex>
   );
 };

--- a/src/pages/SignUpPage/SignUpPage.style.ts
+++ b/src/pages/SignUpPage/SignUpPage.style.ts
@@ -1,6 +1,5 @@
 import styled from '@emotion/styled';
 import * as Checkbox from '@radix-ui/react-checkbox';
-import { Link } from 'react-router-dom';
 import { Button } from '@radix-ui/themes';
 
 export const Container = styled.div`

--- a/src/router/AppRouter.tsx
+++ b/src/router/AppRouter.tsx
@@ -25,14 +25,6 @@ const AppRouter = () => {
           ),
         },
         {
-          path: PATH.CONTACT_US,
-          element: (
-            <Suspense>
-              <Lazy.ContactUsPage />
-            </Suspense>
-          ),
-        },
-        {
           path: PATH.CREATE_PLAYGROUND,
           element: (
             <Suspense>
@@ -157,6 +149,14 @@ const AppRouter = () => {
           element: (
             <Suspense>
               <Lazy.PlaygroundSearchPage />
+            </Suspense>
+          ),
+        },
+        {
+          path: PATH.FRIEND_MESSAGE(':userId'),
+          element: (
+            <Suspense>
+              <Lazy.FriendMessagePage />
             </Suspense>
           ),
         },

--- a/src/router/lazy.ts
+++ b/src/router/lazy.ts
@@ -1,6 +1,6 @@
 import { lazy } from 'react';
 
-export const ContactUsPage = lazy(() => import('@pages/ContactUsPage/ContactUsPage'));
+export const FriendMessagePage = lazy(() => import('@/pages/FriendMessagePage/FriendMessagePage'));
 
 export const CreatePlaygroundPage = lazy(
   () => import('@pages/CreatePlaygroundPage/CreatePlaygroundPage'),

--- a/src/types/message.d.ts
+++ b/src/types/message.d.ts
@@ -1,0 +1,1 @@
+export type DirectMessageType = (typeof DIRECT_MESSAGE)[keyof typeof DIRECT_MESSAGE];


### PR DESCRIPTION
## 🚀 Related Issues

> #19 

## 🛠️ Summary

- 기존에 contact-us 페이지를 삭제 하고 대신 friend-message 페이지를 추가 하였습니다.
- 쪽지와 관련된 공통 컴포넌트인 Card 컴포넌트를 추가하였습니다.
![image](https://github.com/user-attachments/assets/8db4d134-31f7-447b-a100-a1dcb547f166)
- 모집글 컴포넌트를 추가하였습니다.
![image](https://github.com/user-attachments/assets/e39935c2-441e-4fc9-ba1b-37558ad09dcd)
- 쪽지 관련한 탭 컴포넌트와 관련된 훅, 상수를 추가하였습니다.
- 신고와 쪽지 보낼때 사용하는 TextArea를 컴포넌트로 따로 분리하였습니다.
- 쪽지함 조회 페이지를 퍼블리싱하였습니다.
- 모집글리스트 들어가면 나오는 쪽지함 페이지를 퍼블리싱하였습니다.


## 💬 Review Requirements

- [SignUpPage.style.ts](https://github.com/SWYP-Playground/Playground-Front/commit/662cfd57d035f5699a407dbd438d209498f891d8#diff-3e055e0c774242f6f7a5b957f882b500382057ef768fd7676c3ab07963cbfa7a) 해당 파일에서 Link를 선언해주었는데 사용하지 않아 build 오류가 나서 해당 코드 삭제하였습니다.
