### PR TITLE
도로명주소 수정 / 에러 페이지 리팩토링

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,8 +10,10 @@ import { useResetError } from '@hooks/common/useResetError';
 import BottomNav from '@components/layout/BottomNav/BottomNav';
 
 function App() {
+  const { handleErrorReset } = useResetError();
+
   return (
-    <ErrorBoundary Fallback={Error} onReset={useResetError}>
+    <ErrorBoundary Fallback={Error} onReset={handleErrorReset}>
       <Login>
         <div style={{ display: 'flex', flexDirection: 'column', maxHeight: '100dvh' }}>
           <main

--- a/src/components/common/Error/Error.style.ts
+++ b/src/components/common/Error/Error.style.ts
@@ -1,0 +1,27 @@
+import styled from '@emotion/styled';
+import { Button, Flex } from '@radix-ui/themes';
+
+export const ErrorFlex = styled(Flex)`
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100dvh;
+  flex: 1;
+`;
+
+export const ErrorMessage = styled.span`
+  font-size: 30px;
+  font-weight: 800;
+`;
+
+export const ErrorButton = styled(Button)`
+  font-weight: 600;
+  margin-top: 20px;
+  padding: 20px;
+  width: 300px;
+  border-radius: 8px;
+  box-shadow: 0px 2px 8px #e9b035;
+  cursor: pointer;
+  background-color: ${({ theme }) => theme.colors.primary1};
+  color: ${({ theme }) => theme.colors.black900};
+`;

--- a/src/components/common/Error/Error.tsx
+++ b/src/components/common/Error/Error.tsx
@@ -1,6 +1,8 @@
 import { HTTP_ERROR_MESSAGE, HTTP_STATUS_CODE } from '@/constants/api';
 // import { useTokenError } from '@/hooks/member/useTokenError';
 import { hasKeyInObject } from '@/utils/typeGuard';
+import { ErrorButton, ErrorFlex, ErrorMessage } from '@/components/common/Error/Error.style';
+import LogoIcon from '@/assets/svg/logo-vertical.svg?react';
 
 export interface ErrorProps {
   statusCode?: number;
@@ -15,14 +17,16 @@ const Error = ({ statusCode = HTTP_STATUS_CODE.NOT_FOUND, errorCode, resetError 
 
   // const { handleTokenError } = useTokenError();
 
-  console.log(errorCode);
+  console.log(errorCode, isHTTPError);
 
-  if (!isHTTPError) return null;
+  // if (!isHTTPError) return null;
 
   return (
-    <>
-      <button onClick={resetError}>에러 리셋하기</button>
-    </>
+    <ErrorFlex>
+      <LogoIcon width="200px" height="200px" />
+      <ErrorMessage>오류가 발생하였습니다!</ErrorMessage>
+      <ErrorButton onClick={resetError}>에러 리셋하기</ErrorButton>
+    </ErrorFlex>
   );
 };
 

--- a/src/components/popUp/SignUpCompletePopup.tsx
+++ b/src/components/popUp/SignUpCompletePopup.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import { Button } from '@radix-ui/themes';
+import LogoVertical from '@/assets/svg/logo-horizon.svg';
 
 interface SignUpCompletePopupProps {
   onClose: () => void;
@@ -9,7 +10,7 @@ const SignUpCompletePopup = ({ onClose }: SignUpCompletePopupProps) => {
   return (
     <PopupContainer>
       <PopupContent>
-        <Logo src="/src/assets/svg/logo-vertical.svg" alt="Playground Logo" />
+        <Logo src={LogoVertical} alt="Playground Logo" />
         <Title>가입 완료</Title>
         <Description>
           프로필을 작성하고

--- a/src/components/profile/EditProfile/ProfileImageSection.tsx
+++ b/src/components/profile/EditProfile/ProfileImageSection.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import AddressSearchModal from './AddressSearchModal';
+import AddressSearchModal from '@/components/profile/EditProfile/AddressSearchModal';
 import {
   InputContainer,
   Label,
@@ -58,7 +58,7 @@ const ProfileImageSection = ({
   };
 
   const handleAddressSelection = (data: any) => {
-    const placeName = data.buildingName || data.address;
+    const placeName = data.address;
     setAddress(placeName);
     onChange('address', placeName);
     setIsPostcodeVisible(false);

--- a/src/constants/path.ts
+++ b/src/constants/path.ts
@@ -1,7 +1,6 @@
 export const PATH = {
   ROOT: '/',
   SIGNUP: '/sign-up',
-  SIGNUP_COMPLETE: '/sign-up/complete',
   SIGNIN: '/sign-in',
   FIND_ACCOUNT: '/find-account',
   FIND_PLAYGROUND_FRIEND: '/find-playground-friend',

--- a/src/pages/SignUpCompletePage/SignUpCompletePage.tsx
+++ b/src/pages/SignUpCompletePage/SignUpCompletePage.tsx
@@ -1,5 +1,0 @@
-const SignUpCompletePage = () => {
-  return <div>회원가입완료페이지입니다.</div>;
-};
-
-export default SignUpCompletePage;

--- a/src/pages/SignUpCompletePage/SignUpCompletePage.tsx
+++ b/src/pages/SignUpCompletePage/SignUpCompletePage.tsx
@@ -1,0 +1,5 @@
+const SignUpCompletePage = () => {
+  return <div>회원가입완료페이지입니다.</div>;
+};
+
+export default SignUpCompletePage;

--- a/src/router/AppRouter.tsx
+++ b/src/router/AppRouter.tsx
@@ -145,6 +145,14 @@ const AppRouter = () => {
           ),
         },
         {
+          path: PATH.SIGNUP_COMPLETE,
+          element: (
+            <Suspense>
+              <Lazy.SignUpCompletePage />
+            </Suspense>
+          ),
+        },
+        {
           path: PATH.PLAYGROUND_SEARCH,
           element: (
             <Suspense>

--- a/src/router/AppRouter.tsx
+++ b/src/router/AppRouter.tsx
@@ -145,14 +145,6 @@ const AppRouter = () => {
           ),
         },
         {
-          path: PATH.SIGNUP_COMPLETE,
-          element: (
-            <Suspense>
-              <Lazy.SignUpCompletePage />
-            </Suspense>
-          ),
-        },
-        {
           path: PATH.PLAYGROUND_SEARCH,
           element: (
             <Suspense>

--- a/src/router/lazy.ts
+++ b/src/router/lazy.ts
@@ -39,6 +39,10 @@ export const ReportFriendPage = lazy(() => import('@/pages/ReportFriendPage/Repo
 
 export const SignInPage = lazy(() => import('@/pages/SignInPage/SignInPage'));
 
+export const SignUpCompletePage = lazy(
+  () => import('@/pages/SignUpCompletePage/SignUpCompletePage'),
+);
+
 export const SignUpPage = lazy(() => import('@/pages/SignUpPage/SignUpPage'));
 
 export const PlaygroundSearchPage = lazy(

--- a/src/router/lazy.ts
+++ b/src/router/lazy.ts
@@ -39,10 +39,6 @@ export const ReportFriendPage = lazy(() => import('@/pages/ReportFriendPage/Repo
 
 export const SignInPage = lazy(() => import('@/pages/SignInPage/SignInPage'));
 
-export const SignUpCompletePage = lazy(
-  () => import('@/pages/SignUpCompletePage/SignUpCompletePage'),
-);
-
 export const SignUpPage = lazy(() => import('@/pages/SignUpPage/SignUpPage'));
 
 export const PlaygroundSearchPage = lazy(


### PR DESCRIPTION
## 🚀 Related Issues

> #58 

## 🛠️ Summary

- 회원가입 완료후 프로필 작성 모달 뜨는 화면에서 로고가 보이지 않던 버그를 수정하였습니다.
- 프로필 작성의 주소 부분에서 카카오 지도 주소 검색후에 건물 이름이 들어가는 걸 뒤늦게 확인해서 도로명 주소가 form에 들어가도록 수정하였습니다.
- 에러페이지 화면을 수정하였습니다.

## 💬 Review Requirements

> 3c93edd7ca12754a5a47bb7b5e9d503d0067e4ba
